### PR TITLE
Rewritting counting/filling loops in rapid_mus_mat.f90

### DIFF
--- a/src/rapid_mus_mat.F90
+++ b/src/rapid_mus_mat.F90
@@ -141,28 +141,43 @@ end if
 JS_i=2
 do while ( COUNT( (IV_cols(1:IS_riv_bas).eq.0) ).ne.IS_riv_bas )
 
-    IV_nz(JS_i)=COUNT( (IV_cols(1:IS_riv_bas).ne.0) ) 
+    do JS_riv_bas=1,IS_riv_bas
+        if ( IV_cols(JS_riv_bas).ne.0 ) then
 
-    if ( (JS_i.ge.IS_ownfirst+1).and.(JS_i.lt.IS_ownlast+1) ) then
-        do JS_riv_bas=1,IS_riv_bas
-            if ( IV_cols(JS_riv_bas).ne.0 ) then
-                if ( (JS_riv_bas.ge.IS_ownfirst+1).and. &
-                     (JS_riv_bas.lt.IS_ownlast+1) ) then
-                    IV_dnz(JS_i)=IV_dnz(JS_i)+1
-                end if
-                IV_cols(JS_riv_bas)=IV_cols_duplicate(IV_cols(JS_riv_bas))
-            end if
-        end do
-        IV_onz(JS_i)=IV_nz(JS_i)-IV_dnz(JS_i)
+            call VecGetValues(ZV_all,              &
+                              IS_one,                  &
+                              IV_cols(JS_riv_bas)-1,   &
+                              ZS_val,ierr)
 
-    else
-        do JS_riv_bas=1,IS_riv_bas
-            if ( IV_cols(JS_riv_bas).ne.0 ) then
-                IV_cols(JS_riv_bas)=IV_cols_duplicate(IV_cols(JS_riv_bas))
-            end if
-        end do
+            if ( ABS(ZV_cols(JS_riv_bas)*ZS_val).ge.ZS_threshold ) then
 
-    end if
+                IV_nz(JS_i) = IV_nz(JS_i)+1
+                
+                if (((JS_i.ge.IS_ownfirst+1).and.      &
+                     (JS_i.lt.IS_ownlast+1)).and.      &
+                    ((JS_riv_bas.ge.IS_ownfirst+1).and.&
+                     (JS_riv_bas.lt.IS_ownlast+1))) then 
+                    IV_dnz(JS_i) = IV_dnz(JS_i)+1
+                endif
+
+                if (((JS_i.ge.IS_ownfirst+1).and.      &
+                     (JS_i.lt.IS_ownlast+1)).and.      &
+                    ((JS_riv_bas.lt.IS_ownfirst+1).or.&
+                     (JS_riv_bas.ge.IS_ownlast+1))) then 
+                    IV_onz(JS_i) = IV_onz(JS_i)+1
+                endif
+
+                IV_nbrows(JS_riv_bas) = IV_nbrows(JS_riv_bas)+1
+                ZV_cols(JS_riv_bas) = ZV_cols(JS_riv_bas)*ZS_val
+                IV_cols(JS_riv_bas) = IV_cols_duplicate(IV_cols(JS_riv_bas))
+            else
+
+                IV_cols(JS_riv_bas) = 0        
+            endif
+
+        endif
+    enddo       
+
     JS_i=JS_i+1
 end do
 IS_Knilpotent=JS_i-1

--- a/src/rapid_mus_mat.F90
+++ b/src/rapid_mus_mat.F90
@@ -366,30 +366,34 @@ if (rank==0) then
 deallocate(ZV_cols)
 
 
-do JS_riv_bas=0,IS_riv_bas-1
+do JS_riv_bas=1,IS_riv_bas
 
-    IV_rows(1)=JS_riv_bas+1
-    do JS_i=2,IV_nbrows(JS_riv_bas+1)
-        IV_rows(JS_i)=IV_cols(IV_rows(JS_i-1))
+    do JS_i=1,IV_nbrows(JS_riv_bas)  
+        if (JS_i.eq.1) then
+            IV_rows(JS_i) = JS_riv_bas  !row index
+        else
+            IV_rows(JS_i)=IV_cols_duplicate(IV_rows(JS_i-1)) 
+        endif
     end do
-    allocate(ZV_cols(IV_nbrows(JS_riv_bas+1)))
+    allocate(ZV_cols(IV_nbrows(JS_riv_bas)))
     
     call MatGetValues( ZM_MC,    &
-                       IV_nbrows(JS_riv_bas+1),  &
-                       IV_ind(1:IV_nbrows(JS_riv_bas+1))-1,   &
-                       IS_one,JS_riv_bas,   &
+                       IV_nbrows(JS_riv_bas),  &
+                       IV_ind(1:IV_nbrows(JS_riv_bas))-1,   &
+                       IS_one,JS_riv_bas-1,   &
                        ZV_cols,ierr )
 
     call MatSetValues( ZM_M,    &
-                       IV_nbrows(JS_riv_bas+1),  &
-                       IV_rows(1:IV_nbrows(JS_riv_bas+1))-1,   & 
-                       IS_one, JS_riv_bas,   &
-                       ZV_cols(1:IV_nbrows(JS_riv_bas+1)),  &
+                       IV_nbrows(JS_riv_bas),  &
+                       IV_rows(1:IV_nbrows(JS_riv_bas))-1,   & 
+                       IS_one, JS_riv_bas-1,   &
+                       ZV_cols(1:IV_nbrows(JS_riv_bas)),  &
                        INSERT_VALUES,ierr )
 
     deallocate(ZV_cols)
 
 end do
+
 
 end if
 

--- a/src/rapid_mus_mat.F90
+++ b/src/rapid_mus_mat.F90
@@ -349,6 +349,7 @@ if (IS_opt_run/=2) call PetscPrintf(PETSC_COMM_WORLD,'Muskingum matrix '       &
 !Allocate and initialize temporary variables
 !-------------------------------------------------------------------------------
 allocate(IV_rows(IS_Knilpotent+1))
+IV_rows(:)=0
 
 !-------------------------------------------------------------------------------
 !Populate temporary variables
@@ -364,7 +365,7 @@ end do
 if (rank==0) then
 deallocate(ZV_cols)
 
-IV_rows(:)=0
+
 do JS_riv_bas=0,IS_riv_bas-1
 
     IV_rows(1)=JS_riv_bas+1

--- a/src/rapid_mus_mat.F90
+++ b/src/rapid_mus_mat.F90
@@ -94,6 +94,14 @@ IV_cols_duplicate(:)=0
 !Used to store the index where each element of MC will be placed in M, IV_cols
 !is updated for every power of N.
 
+allocate(IV_nbrows(IS_riv_bas))
+IV_nbrows(:)=1
+!Used to store, for each column of ZM_MC, how many non-zeros rows
+
+allocate(ZV_cols(IS_riv_bas))
+ZV_cols(:)=1
+!Used to store, for a given row of ZM_MC, the element values for each column
+
 IV_nz(:)=0
 IV_dnz(:)=0
 IV_onz(:)=0
@@ -208,10 +216,7 @@ end do
 !-------------------------------------------------------------------------------
 if (rank==0) then
 
-allocate(ZV_cols(IS_riv_bas))
-allocate(IV_nbrows(IS_riv_bas))
-ZV_cols(:)=1
-IV_nbrows(:)=1
+
 do JS_i=0,IS_Knilpotent
 
     call MatSetValues(ZM_MC,   &

--- a/src/rapid_mus_mat.F90
+++ b/src/rapid_mus_mat.F90
@@ -300,33 +300,33 @@ IV_onz(:)=0
 !-------------------------------------------------------------------------------
 !Count the number of non-zero elements (ZM_MC)
 !-------------------------------------------------------------------------------
-do JS_riv_bas2=1,IS_riv_bas
-     IV_nz(JS_riv_bas2)=1
-     if (IV_nbup(IV_riv_index(JS_riv_bas2)).gt.0) then
-          do JS_up=1,IV_nbup(IV_riv_index(JS_riv_bas2))
+do JS_riv_bas=1,IS_riv_bas   !Loop over column
+    do JS_i=1,IV_nbrows(JS_riv_bas)
+   
+        if (JS_i.eq.1) then
+            JS_riv_bas2 = JS_riv_bas  !row index
+        else
+            JS_riv_bas2 = IV_cols_duplicate(JS_riv_bas2)
+        endif
 
-              JS_riv_bas=IM_index_up(JS_riv_bas2,JS_up)
-              IV_nz(JS_riv_bas2)=IV_nz(JS_riv_bas2)+IV_nz(JS_riv_bas)
+        IV_nz(JS_riv_bas2) = IV_nz(JS_riv_bas2)+1
 
-          end do
-     end if
-end do
-
-do JS_riv_bas=1,IS_riv_bas   !loop over column
-    JS_riv_bas2=IV_cols_duplicate(JS_riv_bas)
-    do while (JS_riv_bas2.ne.0)    !loop over row
-        if ( ((JS_riv_bas2.ge.IS_ownfirst+1).and.(JS_riv_bas2.lt.IS_ownlast+1)).and.   &
-             ((JS_riv_bas.ge.IS_ownfirst+1).and.(JS_riv_bas.lt.IS_ownlast+1)) ) then
+        if (((JS_riv_bas2.ge.IS_ownfirst+1).and.   &
+             (JS_riv_bas2.lt.IS_ownlast+1)).and.  &
+            ((JS_riv_bas.ge.IS_ownfirst+1).and.   &
+             (JS_riv_bas.lt.IS_ownlast+1))) then
             IV_dnz(JS_riv_bas2) = IV_dnz(JS_riv_bas2)+1
-        end if
-        if ( ((JS_riv_bas2.ge.IS_ownfirst+1).and.(JS_riv_bas2.lt.IS_ownlast+1)).and.   &
-             ((JS_riv_bas.lt.IS_ownfirst+1).or.(JS_riv_bas.ge.IS_ownlast+1)) ) then
-            IV_onz(JS_riv_bas2) = IV_onz(JS_riv_bas2)+1
-        end if
-        JS_riv_bas2=IV_cols_duplicate(JS_riv_bas2)
-    end do
-end do
+        endif
 
+        if (((JS_riv_bas2.ge.IS_ownfirst+1).and.   &
+             (JS_riv_bas2.lt.IS_ownlast+1)).and.  &
+            ((JS_riv_bas.lt.IS_ownfirst+1).or.    &
+             (JS_riv_bas.ge.IS_ownlast+1))) then
+            IV_onz(JS_riv_bas2) = IV_onz(JS_riv_bas2)+1
+        endif
+
+    enddo
+enddo
 
 !*******************************************************************************
 !Matrix preallocation (ZM_M)

--- a/src/rapid_mus_mat.F90
+++ b/src/rapid_mus_mat.F90
@@ -293,11 +293,9 @@ call MatAssemblyEnd(ZM_MC,MAT_FINAL_ASSEMBLY,ierr)
 !-------------------------------------------------------------------------------
 !Allocate and initialize temporary variables
 !-------------------------------------------------------------------------------
-do JS_riv_bas=1,IS_riv_bas
-     IV_nz(JS_riv_bas)=0
-     IV_dnz(JS_riv_bas)=1
-     IV_onz(JS_riv_bas)=0
-end do
+IV_nz(:)=0
+IV_dnz(:)=0
+IV_onz(:)=0
 
 !-------------------------------------------------------------------------------
 !Count the number of non-zero elements (ZM_MC)

--- a/src/rapid_mus_mat.F90
+++ b/src/rapid_mus_mat.F90
@@ -211,7 +211,7 @@ call MatMPIAIJSetPreallocation(ZM_MC,                                          &
 !Allocate and initialize temporary variables
 !-------------------------------------------------------------------------------
 allocate(IV_ind(IS_riv_bas))
-!
+
 
 !-------------------------------------------------------------------------------
 !Populate temporary variables
@@ -221,9 +221,13 @@ do JS_riv_bas=1,IS_riv_bas
 end do
 !Reset the value of IV_cols
 
+ZV_cols(:)=1
+!Reset the values of ZV_cols
+
 do JS_riv_bas=1,IS_riv_bas
     IV_ind(JS_riv_bas) = JS_riv_bas
 end do
+!Initialize IV_ind
 
 
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
The main changes with the new commits are:
- Creation and use of a new VecScatter object ZV_all that will be duplicated over all processors, instead of using ZV_SeqZero that is available only on the zeroth processor,
- Rewritting/reorganization of both non-zeros counting and filling loops for ZM_MC and ZM_M, so that counting and filling procedure follow the same pattern,
- Some allocations/initializations have been moved to match the new loops and also fit better into the routine outlines.

Also, IMPORTANT: I look into including the case of broken network (with rapid_net_mat_break.f90) when initializing IV_cols/IV_cols_duplicate. These two vectors are initialized using IM_index_up. However, the IM_index_up variable is updated, along with ZM_Net, in rapid_net_mat_break.f90. So, the case of broken network seems to be accounted for.