### PR TITLE
Subroutine rapid_cov_mat.F90

### DIFF
--- a/src/rapid_cov_mat.F90
+++ b/src/rapid_cov_mat.F90
@@ -211,6 +211,9 @@ end if
 call MatAssemblyBegin(ZM_Pb,MAT_FINAL_ASSEMBLY,ierr)
 call MatAssemblyEnd(ZM_Pb,MAT_FINAL_ASSEMBLY,ierr)
 
+call PetscPrintf(PETSC_COMM_WORLD,'Runoff error covariance matrix created'       &
+                                  //char(10),ierr)
+
 
 !*******************************************************************************
 !Free up memory used by local (temporary) variables

--- a/src/rapid_cov_mat.F90
+++ b/src/rapid_cov_mat.F90
@@ -108,6 +108,7 @@ do JS_riv_bas=1,IS_riv_bas   !row index
         if (JS_riv_bas2.ne.0) then
 
             IV_nz(JS_riv_bas) = IV_nz(JS_riv_bas)+1
+            IV_nz(JS_riv_bas2) = IV_nz(JS_riv_bas2)+1  !symmetry
 
             if (((JS_riv_bas.ge.IS_ownfirst+1).and.      &
                  (JS_riv_bas.lt.IS_ownlast+1)).and.      &
@@ -115,6 +116,7 @@ do JS_riv_bas=1,IS_riv_bas   !row index
                  (JS_riv_bas2.lt.IS_ownlast+1))) then
  
                 IV_dnz(JS_riv_bas) = IV_dnz(JS_riv_bas)+1
+                IV_dnz(JS_riv_bas2) = IV_dnz(JS_riv_bas2)+1  !symmetry
 
             endif
 
@@ -125,6 +127,15 @@ do JS_riv_bas=1,IS_riv_bas   !row index
  
                 IV_onz(JS_riv_bas) = IV_onz(JS_riv_bas)+1
                 
+            endif
+
+            if (((JS_riv_bas.lt.IS_ownfirst+1).or.       &
+                 (JS_riv_bas.ge.IS_ownlast+1)).and.      &
+                ((JS_riv_bas2.ge.IS_ownfirst+1).and.      &
+                 (JS_riv_bas2.lt.IS_ownlast+1))) then
+
+                IV_onz(JS_riv_bas2) = IV_onz(JS_riv_bas2)+1
+
             endif
 
             JS_riv_bas2 = IV_index_down(JS_riv_bas2)

--- a/src/rapid_cov_mat.F90
+++ b/src/rapid_cov_mat.F90
@@ -189,6 +189,15 @@ do JS_riv_bas=1,IS_riv_bas   !row index
                              ZV_riv_tot_cdownQlat(IV_riv_index(JS_riv_bas),JS_i),     &
                              INSERT_VALUES,ierr)
 
+            !populate symetruc elemtns
+            call MatSetValues(ZM_Pb,                                              &
+                             IS_one,                                              &
+                             JS_riv_bas2-1,                                       &
+                             IS_one,                                              &
+                             JS_riv_bas1-1,                                       &
+                             ZV_riv_tot_cdownQlat(IV_riv_index(JS_riv_bas),JS_i), &
+                             INSERT_VALUES,ierr)
+
             JS_riv_bas2 = IV_index_down(JS_riv_bas2)
 
         end if

--- a/src/rapid_cov_mat.F90
+++ b/src/rapid_cov_mat.F90
@@ -27,7 +27,7 @@ use rapid_var, only :                                                          &
                 !new variables added in rapid_var.F90
                 IS_radius,                                                     &
                 ZM_Pb,                                                         &
-                ZV_riv_tot_vQlat,ZV_riv_tot_cQlat 
+                ZV_riv_tot_vQlat,ZV_riv_tot_cdownQlat 
                 
 
 
@@ -176,7 +176,7 @@ do JS_riv_bas=1,IS_riv_bas   !row index
                              JS_riv_bas-1,                                        &
                              IS_one,                                              &
                              JS_riv_bas2-1,                                       &
-                             ZV_riv_tot_cQlat(IV_riv_index(JS_riv_bas),JS_i),     &
+                             ZV_riv_tot_cdownQlat(IV_riv_index(JS_riv_bas),JS_i),     &
                              INSERT_VALUES,ierr)
 
             JS_riv_bas2 = IV_index_down(JS_riv_bas2)

--- a/src/rapid_cov_mat.F90
+++ b/src/rapid_cov_mat.F90
@@ -150,13 +150,12 @@ end do
 !Matrix preallocation (ZM_Pb)
 !*******************************************************************************
 
-call MatSeqSBAIJSetPreallocation(ZM_Pb,IS_one,PETSC_NULL_INTEGER,IV_nz,ierr)
-call MatMPISBAIJSetPreallocation(ZM_Pb,IS_one,        &
-                                       PETSC_NULL_INTEGER, &
-                                       IV_dnz(IS_ownfirst+1:IS_ownlast),   &
-                                       PETSC_NULL_INTEGER,  &
-                                       IV_onz(IS_ownfirst+1:IS_ownlast),   &
-                                       ierr)
+call MatSeqAIJSetPreallocation(ZM_Pb,PETSC_NULL_INTEGER,IV_nz,ierr)
+call MatMPIAIJSetPreallocation(ZM_Pb,PETSC_NULL_INTEGER, &
+                                     IV_dnz(IS_ownfirst+1:IS_ownlast),   &
+                                     PETSC_NULL_INTEGER,  &
+                                     IV_onz(IS_ownfirst+1:IS_ownlast),   &
+                                     ierr)
 
 
 !*******************************************************************************

--- a/src/rapid_kf_cov_mat.F90
+++ b/src/rapid_kf_cov_mat.F90
@@ -1,0 +1,85 @@
+!*******************************************************************************
+!Subroutine - rapid_kf_cov_mat
+!*******************************************************************************
+subroutine rapid_kf_cov_mat
+
+
+!Purpose:
+!Compute runoff error covariance matrices in Kalman gain
+!ZM_HPbt = (ZM_Pb*ZM_H^(T))^(T)
+!ZM_HPbHt = ZM_H*ZM_Pb*ZM_H^(T)
+!Authors: 
+!Charlotte M. Emery, and Cedric H. David, 2018-2018.
+
+!*******************************************************************************
+!Declaration of variables
+!*******************************************************************************
+
+
+
+use rapid_var, only :                                                          &
+                ZM_Pb,ZM_H,ZM_HPbt,ZM_HPbHt,ierr
+                
+implicit none
+
+
+!*******************************************************************************
+!Includes
+!*******************************************************************************
+#include "petsc/finclude/petscsys.h"
+!base PETSc routines
+#include "petsc/finclude/petscvec.h"
+#include "petsc/finclude/petscvec.h90"
+!vectors, and vectors in Fortran90
+#include "petsc/finclude/petscmat.h"
+!matrices
+#include "petsc/finclude/petscksp.h"
+!Krylov subspace methods
+#include "petsc/finclude/petscpc.h"
+!preconditioners
+#include "petsc/finclude/petscviewer.h"
+!viewers (allows writing results in file for example)
+
+!*******************************************************************************
+!Local variables
+!*******************************************************************************
+
+Mat :: ZM_Ht
+
+!*******************************************************************************
+!Compute matrix ZM_HPbt : H*Pb^(T) = H*Pb as Pb symmetric
+!*******************************************************************************
+
+call MatMatMult(ZM_H,                      &
+                ZM_Pb,                     &
+                MAT_INITIAL_MATRIX,        &
+                PETSC_DEFAULT_REAL,        &
+                ZM_HPbt,                   &
+                ierr)
+
+!*******************************************************************************
+!Compute matrix ZM_HPbHt
+!*******************************************************************************
+
+call MatTranspose(ZM_H,MAT_INITIAL_MATRIX,ZM_Ht,ierr)
+
+call MatMatMult(ZM_HPbt,                   &
+                ZM_Ht,                     &
+                MAT_INITIAL_MATRIX,        &
+                PETSC_DEFAULT_REAL,        &
+                ZM_HPbHt,                   &
+                ierr)
+
+call PetscPrintf(PETSC_COMM_WORLD,'Kalman Filter control error covariance matrix created'  &
+                                  //char(10),ierr)
+
+!*******************************************************************************
+!Delete temporary variables
+!*******************************************************************************
+
+call MatDestroy(ZM_Ht,ierr)
+
+!*******************************************************************************
+!End subroutine 
+!*******************************************************************************
+end subroutine rapid_kf_cov_mat

--- a/src/rapid_kf_obs_mat.F90
+++ b/src/rapid_kf_obs_mat.F90
@@ -1,0 +1,174 @@
+!*******************************************************************************
+!Subroutine - rapid_kf_obs_mat
+!*******************************************************************************
+subroutine rapid_kf_obs_mat
+
+!Purpose:
+!Using the set of available observation gage,
+!Compute the observation operator for data assimilation (ZM_H)
+!This operator is a submatrix of runoff-to-discharge operator (ZM_L)
+!As it contains only the rows of ZM_L that corresponds to potentially 
+!observed reach
+!Authors: 
+!Charlotte M. Emery, and Cedric H. David, 2018-2018.
+
+!*******************************************************************************
+!Declaration of variables
+!*******************************************************************************
+
+use rapid_var, only :                                                          &
+                IV_riv_loc1,IS_riv_bas,JS_riv_bas,                             &
+                IV_obs_loc1,IS_obs_bas,JS_obs_bas,                             &
+                ierr,rank,                                                     &
+                IS_one,ZS_one,                                                 &
+                ZM_L,ZM_S,ZM_H
+
+implicit none
+
+!*******************************************************************************
+!Includes
+!*******************************************************************************
+#include "petsc/finclude/petscsys.h"
+!base PETSc routines
+#include "petsc/finclude/petscvec.h"
+#include "petsc/finclude/petscvec.h90"
+!vectors, and vectors in Fortran90
+#include "petsc/finclude/petscmat.h"
+!matrices
+#include "petsc/finclude/petscksp.h"
+!Krylov subspace methods
+#include "petsc/finclude/petscpc.h"
+!preconditioners
+#include "petsc/finclude/petscviewer.h"
+!viewers (allows writing results in file for example)
+
+!*******************************************************************************
+!Intent (in/out), and local variables 
+!*******************************************************************************
+
+PetscInt :: IS_val
+PetscInt :: ISobs_ownfirst, ISobs_ownlast
+
+PetscInt, dimension(:), allocatable :: IV_sorted_obs_loc1, IV_sort
+PetscInt, dimension(:), allocatable :: IVobs_nz, IVobs_dnz, IVobs_onz
+
+!*******************************************************************************
+!Prepare for selection operator preallocation
+!*******************************************************************************
+
+!-------------------------------------------------------------------------------
+!Allocate/Initialize local (temporary variables)
+!-------------------------------------------------------------------------------
+
+allocate(IV_sorted_obs_loc1(IS_obs_bas))
+allocate(IV_sort(IS_obs_bas))
+
+allocate(IVobs_nz(IS_obs_bas))
+allocate(IVobs_dnz(IS_obs_bas))
+allocate(IVobs_onz(IS_obs_bas))
+
+IVobs_nz(:) = 1
+IVobs_dnz(:) = 1
+IVobs_onz(:) = 0
+
+!-------------------------------------------------------------------------------
+!Sort observation gages from upstream to downstream
+!-------------------------------------------------------------------------------
+
+do JS_obs_bas = 1,IS_obs_bas
+    IV_sort(JS_obs_bas) = IV_obs_loc1(JS_obs_bas)
+end do
+
+do JS_obs_bas = 1,IS_obs_bas
+    IS_val = MINLOC(IV_sort,DIM=1)
+    IV_sorted_obs_loc1(JS_obs_bas) = IV_sort(IS_val)
+    IV_sort(IS_val) = MAXVAL(IV_sort)+1   
+end do
+
+!-------------------------------------------------------------------------------
+!Create observation operator matrix
+!-------------------------------------------------------------------------------
+
+call MatCreate(PETSC_COMM_WORLD,ZM_S,ierr)
+call MatSetSizes(ZM_S,PETSC_DECIDE,PETSC_DECIDE,IS_obs_bas,IS_riv_bas,ierr)
+call MatSetFromOptions(ZM_S,ierr)
+call MatSetUp(ZM_S,ierr)
+
+!-------------------------------------------------------------------------------
+!Count non-zeros in ZM_S
+!-------------------------------------------------------------------------------
+
+call MatGetOwnershipRange(ZM_S,ISobs_ownfirst,ISobs_ownlast,ierr) 
+
+do JS_obs_bas = 1,IS_obs_bas
+
+    IS_val = IV_sorted_obs_loc1(JS_obs_bas)
+
+    if (((JS_obs_bas.ge.ISobs_ownfirst+1).and.(JS_obs_bas.lt.ISobs_ownlast+1)).and.   &
+        ((IS_val.ge.ISobs_ownfirst).and.(IS_val.lt.ISobs_ownlast))) then
+        IVobs_dnz(JS_obs_bas) = 1
+    end if
+
+    if (((JS_obs_bas.ge.ISobs_ownfirst+1).and.(JS_obs_bas.lt.ISobs_ownlast+1)).and.   &
+        ((IS_val.lt.ISobs_ownfirst).or.(IS_val.ge.ISobs_ownlast))) then
+        IVobs_onz(JS_obs_bas) = 1
+    end if
+end do
+
+
+!*******************************************************************************
+!Selection operator preallocation
+!*******************************************************************************
+
+call MatSeqAIJSetPreallocation(ZM_S,PETSC_NULL_INTEGER,IVobs_nz,ierr)
+call MatMPIAIJSetPreallocation(ZM_S,                                           &
+                               PETSC_NULL_INTEGER,                             &
+                               IVobs_dnz(ISobs_ownfirst+1:ISobs_ownlast),      &
+                               PETSC_NULL_INTEGER,                             &
+                               IVobs_onz(ISobs_ownfirst+1:ISobs_ownlast),ierr)
+
+!*******************************************************************************
+!Compute operator preallocation
+!*******************************************************************************
+
+if (rank.eq.0) then
+
+do JS_obs_bas = 1,IS_obs_bas
+    IS_val = IV_sorted_obs_loc1(JS_obs_bas)
+
+    call MatSetValues(ZM_S,                         &
+                      IS_one,                       &
+                      JS_obs_bas-1,                 &
+                      IS_one,                       &
+                      IS_val,                       &
+                      ZS_one,                       &
+                      INSERT_VALUES,ierr)
+                      
+end do
+
+end if
+
+call MatAssemblyBegin(ZM_S,MAT_FINAL_ASSEMBLY,ierr)
+call MatAssemblyEnd(ZM_S,MAT_FINAL_ASSEMBLY,ierr)
+
+!*******************************************************************************
+!Compute observation operator ZM_H = ZM_S*ZM_L
+!*******************************************************************************
+
+call MatMatMult(ZM_S,ZM_L,MAT_INITIAL_MATRIX,PETSC_DEFAULT_REAL,ZM_H,ierr)
+
+call PetscPrintf(PETSC_COMM_WORLD,'Observation operator ZM_H created'//char(10),ierr)
+
+!*******************************************************************************
+!Free up memory used by local (temporary) variables
+!*******************************************************************************
+
+deallocate(IV_sorted_obs_loc1)
+deallocate(IV_sort)
+
+call MatDestroy(ZM_L,ierr)
+
+!*******************************************************************************
+!End subroutine 
+!*******************************************************************************
+end subroutine rapid_kf_obs_mat

--- a/src/rapid_kf_update.F90
+++ b/src/rapid_kf_update.F90
@@ -1,0 +1,164 @@
+!*******************************************************************************
+!Subroutine - rapid_kf_updade
+!*******************************************************************************
+subroutine rapid_kf_update
+
+!Purpose:
+!Compute the Kalman filter update:
+! dQeb = Pb*H^(T)*( H*Pb*H^(T) + R )^(-1)(Qobs-HQeb)
+!Authors: 
+!Charlotte M. Emery, and Cedric H. David, 2018-2018.
+
+!*******************************************************************************
+!Declaration of variables
+!*******************************************************************************
+
+
+
+use rapid_var, only :                                                          &
+                ierr,ksp2,rank,                                                &
+                ZS_one,ZS_stdobs,                                              &
+                IS_obs_bas,                                                    &
+                ZV_dQeb,ZV_Qbmean,ZV_Qobs,                                     &
+                ZM_S,ZM_HPbt,ZM_HPbHt,                                         &
+                IS_one,ZS_val,                                                 &
+                JS_obs_bas,IS_obs_bas
+                
+implicit none
+
+
+!*******************************************************************************
+!Includes
+!*******************************************************************************
+#include "petsc/finclude/petscsys.h"
+!base PETSc routines
+#include "petsc/finclude/petscvec.h"
+#include "petsc/finclude/petscvec.h90"
+!vectors, and vectors in Fortran90
+#include "petsc/finclude/petscmat.h"
+!matrices
+#include "petsc/finclude/petscksp.h"
+!Krylov subspace methods
+#include "petsc/finclude/petscpc.h"
+!preconditioners
+#include "petsc/finclude/petscviewer.h"
+!viewers (allows writing results in file for example)
+
+!*******************************************************************************
+!Local variables
+!*******************************************************************************
+
+Vec :: ZV_D
+Vec :: ZV_R
+Vec :: ZV_xb
+Mat :: ZM_HPbHt_R
+
+!*******************************************************************************
+!Build innovation
+!*******************************************************************************
+
+!-------------------------------------------------------------------------------
+!Build innovation in control space
+!-------------------------------------------------------------------------------
+
+call VecAYPX(ZV_Qbmean,-ZS_one,ZV_Qobs,ierr)
+!ZV_Qb = ZV_Qobs-ZV_Qb
+
+
+!-------------------------------------------------------------------------------
+!Create innovation vector in observation space
+!-------------------------------------------------------------------------------
+
+call VecCreate(PETSC_COMM_WORLD,ZV_D,ierr)
+call VecSetSizes(ZV_D,PETSC_DECIDE,IS_obs_bas,ierr)
+call VecSetFromOptions(ZV_D,ierr)
+
+!-------------------------------------------------------------------------------
+!Build innovation in observation space
+!-------------------------------------------------------------------------------
+
+call MatMult(ZM_S,ZV_Qbmean,ZV_D,ierr)
+!ZV_D = ZM_S*(ZV_Qobs-ZV_Qb)
+
+!*******************************************************************************
+!Build observation error vector
+!*******************************************************************************
+
+!-------------------------------------------------------------------------------
+!Build observation error vector in control space
+!------------------------------------------------------------------------------
+
+call VecScale(ZV_Qobs,ZS_stdobs,ierr)
+call VecPow(ZV_Qobs,2*ZS_one,ierr)
+
+!-------------------------------------------------------------------------------
+!Create observation error vector in observation space
+!-------------------------------------------------------------------------------
+
+call VecCreate(PETSC_COMM_WORLD,ZV_R,ierr)
+call VecSetSizes(ZV_R,PETSC_DECIDE,IS_obs_bas,ierr)
+call VecSetFromOptions(ZV_R,ierr)
+
+!-------------------------------------------------------------------------------
+!Build observation error vector in observation space
+!-------------------------------------------------------------------------------
+
+call MatMult(ZM_S,ZV_Qobs,ZV_R,ierr)
+!ZV_R = ZM_S*(ZS_stdobs*ZV_Qobs)
+
+
+!*******************************************************************************
+!Build ( HPbHt+R )^(-1)*ZV_D
+!*******************************************************************************
+
+!-------------------------------------------------------------------------------
+!Set matrix for linear system
+!-------------------------------------------------------------------------------
+
+call MatDuplicate(ZM_HPbHt,MAT_COPY_VALUES,ZM_HPbHt_R,ierr)
+call MatDiagonalSet(ZM_HPbHt_R,ZV_R,ADD_VALUES,ierr)
+!HPbHt+R
+
+call KSPSetOperators(ksp2,ZM_HPbHt_R,ZM_HPbHt_R,ierr)
+!Set KSP2 to use matrix ZM_HPbHt
+
+!-------------------------------------------------------------------------------
+!Create linear system unknown vector
+!-------------------------------------------------------------------------------
+
+call VecCreate(PETSC_COMM_WORLD,ZV_xb,ierr)
+call VecSetSizes(ZV_xb,PETSC_DECIDE,IS_obs_bas,ierr)
+call VecSetFromOptions(ZV_xb,ierr)
+
+!-------------------------------------------------------------------------------
+!Solve linear system
+!-------------------------------------------------------------------------------
+
+call KSPSolve(ksp2,ZV_D,ZV_xb,ierr)
+!ZV_xb = ( ZM_HPbHt+diag(ZV_R) )^(-1)*ZV_D
+!ZV_xb = ( HPbHt+R )^(-1)*(yo-Hxb)
+
+
+!*******************************************************************************
+!Compute kalman update
+!*******************************************************************************
+
+call MatMultTranspose(ZM_HPbt,ZV_xb,ZV_dQeb,ierr)
+!ZV_dQeb = [ZM_HPbt]^(T)*ZV_xb
+!ZV_dQeb = ZM_Pb*ZM_Ht*( HPbHt+R )^(-1)*(yo-Hxb)
+
+
+!*******************************************************************************
+!Delete temporary variables
+!*******************************************************************************
+
+call VecDestroy(ZV_D,ierr)
+call VecDestroy(ZV_R,ierr)
+call VecDestroy(ZV_xb,ierr)
+
+call MatDestroy(ZM_HPbHt_R,ierr)
+
+!*******************************************************************************
+!End subroutine 
+!*******************************************************************************
+end subroutine rapid_kf_update

--- a/src/rapid_runoff2streamflow_mat.F90
+++ b/src/rapid_runoff2streamflow_mat.F90
@@ -1,0 +1,696 @@
+!*******************************************************************************
+!Subroutine - rapid_runoff2streamflow_mat
+!*******************************************************************************
+subroutine rapid_runoff2streamflow_mat
+
+
+!Purpose:
+!Compute operator that turns runoff into streamflow over a day of run
+!This operator is used within the data assimilation as part of the
+!observations operator H in the Kalman gain
+!Authors: 
+!Charlotte M. Emery, and Cedric H. David, 2018-2018.
+
+
+!*******************************************************************************
+!Declaration of variables
+!*******************************************************************************
+
+use rapid_var, only :                                                          &
+                IS_riv_bas,JS_riv_bas,JS_riv_bas2,JS_up,                       &
+                IM_index_up,IV_riv_index,IV_nbup,                              &
+                ZV_C1,ZV_C2,ZV_C3,                                             &
+                ZM_M,                                                          &
+                ierr,rank,                                                     &
+                ZV_temp1,                                                      &
+                ZS_one,IS_one,ZS_val,                                          &
+                IV_nz,IV_dnz,IV_onz,                                           &
+                IS_ownfirst,IS_ownlast,                                        &
+                IS_R,IS_RpM,                                                   &
+    !New variables to add in rapid_var+rapid_mus_mat when linking the code
+                ZM_L,IV_lastrow,IV_nbrows
+
+implicit none
+
+!*******************************************************************************
+!Includes
+!*******************************************************************************
+#include "petsc/finclude/petscsys.h"
+!base PETSc routines
+#include "petsc/finclude/petscvec.h"
+#include "petsc/finclude/petscvec.h90"
+!vectors, and vectors in Fortran90
+#include "petsc/finclude/petscmat.h"
+!matrices
+#include "petsc/finclude/petscksp.h"
+!Krylov subspace methods
+#include "petsc/finclude/petscpc.h"
+!preconditioners
+#include "petsc/finclude/petscviewer.h"
+!viewers (allows writing results in file for example)
+
+!*******************************************************************************
+!Intent (in/out), and local variables 
+!*******************************************************************************
+
+PetscInt :: JS_i, JS_j, JS_p
+PetscInt :: JS_last, JS_next_last
+PetscInt :: found_nz, nb_intersection
+
+PetscScalar :: ZS_val2, ZS_factor
+
+PetscInt, dimension(:), allocatable :: IV_index_down
+PetscInt, dimension(:), allocatable :: IV_ind_rows
+PetscInt, dimension(:), allocatable :: IV_lastrow_save
+
+VecScatter :: vecscat_C1_zeroth, vecscat_C2_zeroth, vecscat_C3_zeroth
+Vec :: ZV_C1_zeroth, ZV_C2_zeroth, ZV_C3_zeroth
+
+Mat :: ZM_temp, ZM_temp2
+Mat :: ZM_temp_pow
+
+!*******************************************************************************
+!Prepare for preallocation of ZM_L and associated temporary matrices
+!*******************************************************************************
+
+!-------------------------------------------------------------------------------
+!Allocate and initialize temporary variables
+!-------------------------------------------------------------------------------
+
+allocate(IV_index_down(IS_riv_bas))
+IV_index_down(:) = 0
+!Indexes of downstream reaches
+
+allocate(IV_lastrow_save(IS_riv_bas))
+!backup of IV_lastrow
+
+!No re-initialization of IV_nz/IV_dnz/IV_onz
+!Contains nonzeros elements of (I-C1*N)^(-1)
+!Used as a starting point to count additional non-zeros
+
+!-------------------------------------------------------------------------------
+!Populate temporary variables
+!-------------------------------------------------------------------------------
+
+do JS_riv_bas2=1,IS_riv_bas 
+    do JS_up=1,IV_nbup(IV_riv_index(JS_riv_bas2))
+        if (IM_index_up(JS_riv_bas2,JS_up)/=0) then
+
+        JS_riv_bas=IM_index_up(JS_riv_bas2,JS_up)
+
+        IV_index_down(JS_riv_bas)=JS_riv_bas2
+
+        end if
+    end do
+end do
+!IV_index_down gives, for each reach, the index of the unique downstream reach
+
+do JS_riv_bas=1,IS_riv_bas
+    IV_lastrow_save(JS_riv_bas)=IV_lastrow(JS_riv_bas)
+end do
+!IV_lastrow is updated when counting nonzeros for
+!preallocation, but
+!original IV_lastrow is needed after when
+!populating the matrices
+
+!-------------------------------------------------------------------------------
+!Create temporary matrices
+!-------------------------------------------------------------------------------
+
+call MatCreate(PETSC_COMM_WORLD,ZM_temp,ierr)
+call MatSetSizes(ZM_temp,PETSC_DECIDE,PETSC_DECIDE,IS_riv_bas,IS_riv_bas,ierr)
+call MatSetFromOptions(ZM_temp,ierr)
+call MatSetUp(ZM_temp,ierr)
+!Fixed matrix equal to (I-C1*N)^(-1)*(C3+C2*N)
+
+call MatCreate(PETSC_COMM_WORLD,ZM_temp_pow,ierr)
+call MatSetSizes(ZM_temp_pow,PETSC_DECIDE,PETSC_DECIDE,IS_riv_bas,IS_riv_bas,ierr)
+call MatSetFromOptions(ZM_temp_pow,ierr)
+call MatSetUp(ZM_temp_pow,ierr)
+!Temporary matrix as successive power of ZM_temp=(I-C1*N)^(-1)*(C3+C2*N)
+
+
+!-------------------------------------------------------------------------------
+!Count number of non-zero elements of (I-C1*N)^(-1)*(C3+C2*N)
+!-------------------------------------------------------------------------------
+
+!IV_nz/IV_dnz/IV_onz already
+!contains number of nonzeros elements of (I-C1*N)^(-1) and depends on ZS_threshold
+!Used as a starting point to count additional non-zeros
+!Non-zeros pattern of matrix (I-C1*N)^(-1) is a subset 
+!of non-zeros pattern of (I-C1*N)^(-1)*(C3+C2*N)
+!For each column of (I-C1*N)^(-1), we count the number of new non-zeros 
+!added when multiplied by (C3+C2*N)
+
+allocate(IV_ind_rows(2))
+!Temporary array
+!Contains indices of non-zeros elements of current column in (C3+C2*N)
+
+do JS_riv_bas = 1,IS_riv_bas-1 !loop over column (no new nz on last col)
+    
+    !Test: possible new non-zeros if::
+    ! - there is a reach downstream the current reach JS_riv_bas
+    ! - there is a reach downstream the last non-zero reach of column JS_riv_bas
+    if ((IV_index_down(JS_riv_bas).ne.0).and.                   &
+        (IV_index_down(IV_lastrow(JS_riv_bas)).ne.0)) then
+
+        !In the matrix (I-C1*N)^(-1)*(C3+C2*N),
+        !the element at location (JS_next_last,JS_riv_bas)~=0 if:
+        ! 1) there are non zeros in column JS_riv_bas of (C3+C2*N)
+        ! 2) there are non-zeros in row JS_next_last of (I-C1*N)^(-1)
+        ! 3) intersection between non-zeros indexes of (1) and (2) is not empty
+
+        ! (1) ::
+        !In column JS_riv_bas of (C3+C2*N)
+        !List of non-zeros elements - at most 2
+        IV_ind_rows(1)=JS_riv_bas
+        IV_ind_rows(2)=IV_index_down(JS_riv_bas)
+
+        ! (2)
+        !In column JS_riv_bas of (I-C1*N)^(-1)
+        !position of the potential next non-zeros in the column
+        JS_next_last=IV_index_down(IV_lastrow(JS_riv_bas))
+        !JS_next_last is the row in (I-C1*N)^(-1) to look for non-zeros
+
+        found_nz = 1
+        do while ((found_nz.eq.1).and.(JS_next_last.ne.0))
+
+            ! (3)
+            ! Check intersection
+            nb_intersection=0
+            do JS_i=1,2 !loop over number of element from (1)
+
+                if (IV_lastrow(IV_ind_rows(JS_i)).eq.JS_next_last) then
+                    nb_intersection=nb_intersection+1
+                end if
+
+                if (IV_lastrow(IV_ind_rows(JS_i)).gt.JS_next_last) then
+                    JS_j=IV_ind_rows(JS_i)
+                    do while (JS_j.lt.JS_next_last)
+                        JS_j=IV_index_down(JS_j)
+                    end do
+                    if (JS_j.eq.JS_next_last) then
+                        nb_intersection=nb_intersection+1
+                    end if
+                end if
+
+            end do
+
+            if (nb_intersection.ne.0) then
+
+                IV_nz(JS_next_last) = IV_nz(JS_next_last)+1
+
+                if (((JS_next_last.ge.IS_ownfirst+1).and.                      &
+                     (JS_next_last.lt.IS_ownlast+1)).and.                      &
+                    ((JS_riv_bas.ge.IS_ownfirst+1).and.                        &
+                     (JS_riv_bas.lt.IS_ownlast+1))) then
+                    IV_dnz(JS_next_last) = IV_dnz(JS_next_last)+1
+                end if
+
+                if (((JS_next_last.ge.IS_ownfirst+1).and.                      &
+                     (JS_next_last.lt.IS_ownlast+1)).and.                      &
+                    ((JS_riv_bas.lt.IS_ownfirst+1).or.                         &
+                     (JS_riv_bas.ge.IS_ownlast+1))) then
+                    IV_onz(JS_next_last) = IV_onz(JS_next_last)+1
+                end if
+
+                IV_lastrow(JS_riv_bas) = JS_next_last
+                JS_next_last=IV_index_down(IV_lastrow(JS_riv_bas))
+
+            else
+
+                found_nz=0
+
+            end if
+
+        end do
+    end if
+end do
+deallocate(IV_ind_rows)
+
+
+!-------------------------------------------------------------------------------
+!Matrix preallocation of temporary matrix ZM_temp=(I-C1*N)^(-1)*(C3+C2*N)
+!-------------------------------------------------------------------------------
+
+call MatSeqAIJSetPreallocation(ZM_temp,PETSC_NULL_INTEGER,IV_nz,ierr)
+call MatMPIAIJSetPreallocation(ZM_temp,                                        &
+                               PETSC_NULL_INTEGER,                             &
+                               IV_dnz(IS_ownfirst+1:IS_ownlast),               &
+                               PETSC_NULL_INTEGER,                             &
+                               IV_onz(IS_ownfirst+1:IS_ownlast),ierr)
+
+!-------------------------------------------------------------------------------
+!Count number of additionnal non-zero elements of (I-N)^(-1) (for ZM_L only)
+!-------------------------------------------------------------------------------
+
+do while ( COUNT(IV_lastrow(1:IS_riv_bas).eq.0).ne.IS_riv_bas )
+
+    do JS_riv_bas=1,IS_riv_bas   !loop over column
+
+        JS_riv_bas2 = IV_index_down(IV_lastrow(JS_riv_bas))
+
+        if (JS_riv_bas2.ne.0) then
+
+            IV_nz(JS_riv_bas2) = IV_nz(JS_riv_bas2)+1
+
+            if (((JS_riv_bas2.ge.IS_ownfirst+1).and.                           &
+                 (JS_riv_bas2.lt.IS_ownlast+1)).and.                           &
+                ((JS_riv_bas.ge.IS_ownfirst+1).and.                            &
+                 (JS_riv_bas.lt.IS_ownlast+1))) then
+   
+                IV_dnz(JS_riv_bas2) = IV_dnz(JS_riv_bas2)+1
+
+            end if
+
+            if (((JS_riv_bas2.ge.IS_ownfirst+1).and.                           &
+                 (JS_riv_bas2.lt.IS_ownlast+1)).and.                           &
+                ((JS_riv_bas.lt.IS_ownfirst+1).or.                             &
+                 (JS_riv_bas.ge.IS_ownlast+1))) then
+   
+                IV_onz(JS_riv_bas2) = IV_onz(JS_riv_bas2)+1
+
+            end if
+
+        endif
+
+        IV_lastrow(JS_riv_bas) = JS_riv_bas2
+
+    end do
+
+end do
+
+!*******************************************************************************
+!Matrix preallocation (ZM_L)
+!*******************************************************************************
+
+call MatSeqAIJSetPreallocation(ZM_L,PETSC_NULL_INTEGER,IV_nz,ierr)
+call MatMPIAIJSetPreallocation(ZM_L,                                           &
+                               PETSC_NULL_INTEGER,                             &
+                               IV_dnz(IS_ownfirst+1:IS_ownlast),               &
+                               PETSC_NULL_INTEGER,                             &
+                               IV_onz(IS_ownfirst+1:IS_ownlast),ierr)
+
+call PetscSynchronizedPrintf(PETSC_COMM_WORLD,'ZM_L pre-allocated'//char(10),ierr)
+
+
+!*******************************************************************************
+!Populate ZM_L and associated matrices
+!*******************************************************************************
+
+!-------------------------------------------------------------------------------
+!Create a temporary VecScatter object
+!-------------------------------------------------------------------------------
+
+call VecScatterCreateToZero(ZV_C1,vecscat_C1_zeroth,ZV_C1_zeroth,ierr)
+call VecScatterCreateToZero(ZV_C2,vecscat_C2_zeroth,ZV_C2_zeroth,ierr)
+call VecScatterCreateToZero(ZV_C3,vecscat_C3_zeroth,ZV_C3_zeroth,ierr)
+!The vector ZV_zeroth contains all elements of ZV_C2 or ZV_C3
+!and is copied on the zeroth processor only
+!This way, the zeroth processor can access all values of ZV_C2 or ZV_C3 
+!which is needed to populate the matrices ZM_L/ZM_temp
+
+call VecScatterBegin(vecscat_C1_zeroth,ZV_C1,ZV_C1_zeroth,                       &
+                     INSERT_VALUES,SCATTER_FORWARD,ierr)
+call VecScatterEnd(vecscat_C1_zeroth,ZV_C1,ZV_C1_zeroth,                         &
+                   INSERT_VALUES,SCATTER_FORWARD,ierr)
+
+call VecScatterBegin(vecscat_C2_zeroth,ZV_C2,ZV_C2_zeroth,                       &
+                     INSERT_VALUES,SCATTER_FORWARD,ierr)
+call VecScatterEnd(vecscat_C2_zeroth,ZV_C2,ZV_C2_zeroth,                         &
+                   INSERT_VALUES,SCATTER_FORWARD,ierr)
+
+call VecScatterBegin(vecscat_C3_zeroth,ZV_C3,ZV_C3_zeroth,                       &
+                     INSERT_VALUES,SCATTER_FORWARD,ierr)
+call VecScatterEnd(vecscat_C3_zeroth,ZV_C3,ZV_C3_zeroth,                         &
+                   INSERT_VALUES,SCATTER_FORWARD,ierr) 
+
+!-------------------------------------------------------------------------------
+!Re-initialize temporary variables
+!-------------------------------------------------------------------------------
+
+do JS_riv_bas=1,IS_riv_bas
+    IV_lastrow(JS_riv_bas)=IV_lastrow_save(JS_riv_bas)
+end do
+
+!-------------------------------------------------------------------------------
+!Poupulate ZM_temp/Initialize ZM_L as (I-C1*N)^(-1)*(C3+C2*N)
+!-------------------------------------------------------------------------------
+
+if (rank==0) then
+
+do JS_riv_bas=1,IS_riv_bas !loop over column
+
+    !For the current colum
+    !IV_ind_rows contains index of non-zero rows of (I-C1*N)^(-1)
+    allocate(IV_ind_rows(IV_nbrows(JS_riv_bas))) 
+    do JS_j=1,IV_nbrows(JS_riv_bas)
+        if (JS_j.eq.1) then
+            IV_ind_rows(JS_j)=JS_riv_bas-1
+            JS_riv_bas2=IV_index_down(JS_riv_bas)
+        else
+            IV_ind_rows(JS_j)=JS_riv_bas2-1
+            JS_riv_bas2=IV_index_down(JS_riv_bas2)
+        end if
+    end do
+
+    ZS_val=0.0
+    ZS_val2=0.0
+
+    ! (1)
+    !Set ZM_L/ZM_temp diagonal element in current column
+    ! 
+
+    !ZS_val=ZV_C3(JS_riv_bas)
+    call VecGetValues(ZV_C3_zeroth,                                            &
+                      IS_one,                                                  &
+                      JS_riv_bas-1,                                            &
+                      ZS_val,ierr)
+
+    !ZM_L(JS_riv_bas,JS_riv_bas) = ZV_C3(JS_riv_bas)
+    call MatSetValues(ZM_L,                                                    &
+                      IS_one,JS_riv_bas-1,                                     &
+                      IS_one,JS_riv_bas-1,                                     &
+                      ZS_val,INSERT_VALUES,                                    &
+                      ierr)   
+
+    call MatSetValues(ZM_temp,                                                 &
+                      IS_one,JS_riv_bas-1,                                     &
+                      IS_one,JS_riv_bas-1,                                     &
+                      ZS_val,INSERT_VALUES,                                    &
+                      ierr) 
+
+    if ((IV_index_down(JS_riv_bas).ne.0).and.(IV_nbrows(JS_riv_bas).gt.1)) then
+
+        ! (2)
+        !Set ZM_L/ZM_temp first element downstream diagonal in current column
+        !
+
+        !ZS_val2=ZV_C1( down(JS_riv_bas) )
+        call VecGetValues(ZV_C1_zeroth,                                        &
+                          IS_one,                                              &
+                          IV_index_down(JS_riv_bas)-1,                         &
+                          ZS_val2,ierr)
+
+        !ZS_val = ZS_val*ZV_C1( down(JS_riv_bas) )
+        ZS_val = ZS_val*ZS_val2
+
+        !ZS_val2=ZV_C2( down(JS_riv_bas) )
+        call VecGetValues(ZV_C2_zeroth,                                        &
+                          IS_one,                                              &
+                          IV_index_down(JS_riv_bas)-1,                         &
+                          ZS_val2,ierr)
+
+        !ZS_val = ZS_val + ZV_C2( down(JS_riv_bas) )
+        !ZS_val = ZV_C3(JS_riv_bas)*ZV_C1( down(JS_riv_bas) ) + ZV_C2( down(JS_riv_bas) )
+        ZS_val = ZS_val + ZS_val2
+        
+        !ZM_L(down(JS_riv_bas),JS_riv_bas) = ZS_val
+        call MatSetValues(ZM_L,                                                &
+                          IS_one,IV_index_down(JS_riv_bas)-1,                  &
+                          IS_one,JS_riv_bas-1,                                 &
+                          ZS_val,INSERT_VALUES,                                &
+                          ierr)   
+
+        call MatSetValues(ZM_temp,                                             &
+                          IS_one,IV_index_down(JS_riv_bas)-1,                  &
+                          IS_one,JS_riv_bas-1,                                 &
+                          ZS_val,INSERT_VALUES,                                &
+                          ierr) 
+
+        ! (3)
+        !Set other non-zeros elements in column JS_riv_bas
+        !over the non-zero mask of (I-C1*N)^(-1)
+        !
+
+        do JS_j=3,IV_nbrows(JS_riv_bas)
+
+            !ZS_val2=ZV_C1( IV_ind_rows(JS_j) )
+            call VecGetValues(ZV_C1_zeroth,                                    &
+                              IS_one,                                          &
+                              IV_ind_rows(JS_j),                               &
+                              ZS_val2,ierr)
+
+            !ZS_val = ZS_val*ZS_val2
+            ZS_val = ZS_val*ZS_val2
+
+            !ZM_L(IV_ind_rows(JS_j),JS_riv_bas) = ZV_C1(IV_ind_rows(JS_j))* 
+            !                                     ZM_L(IV_ind_rows(JS_j-1),JS_riv_bas)
+            call MatSetValues(ZM_L,                                            &
+                              IS_one,IV_ind_rows(JS_j),                        &
+                              IS_one,JS_riv_bas-1,                             &
+                              ZS_val,INSERT_VALUES,                            &
+                              ierr)   
+
+            call MatSetValues(ZM_temp,                                         &
+                              IS_one,IV_ind_rows(JS_j),                        &
+                              IS_one,JS_riv_bas-1,                             &
+                              ZS_val,INSERT_VALUES,                            &
+                              ierr)
+
+        end do
+
+    end if
+
+    deallocate(IV_ind_rows)
+
+    ! (4) ::
+    ! Set new non-zeros elements due to the product with (C3+C2*N)
+    !
+
+    allocate(IV_ind_rows(2))
+    IV_ind_rows(1)=JS_riv_bas
+    IV_ind_rows(2)=IV_index_down(JS_riv_bas)
+
+    found_nz = 1
+    JS_next_last=IV_index_down(IV_lastrow(JS_riv_bas))
+    do while ((found_nz.eq.1).and.(JS_next_last.ne.0))
+
+        !JS_next_last is the row in (I-C1*N)^(-1) to look for non-zeros
+        JS_next_last=IV_index_down(IV_lastrow(JS_riv_bas))
+
+        nb_intersection=0
+        do JS_i=1,2 !loop over number of element from (1)
+
+            if (IV_lastrow(IV_ind_rows(JS_i)).eq.JS_next_last) then
+                nb_intersection=nb_intersection+1
+            end if
+
+            if (IV_lastrow(IV_ind_rows(JS_i)).gt.JS_next_last) then
+                JS_j=IV_ind_rows(JS_i)
+                do while (JS_j.lt.JS_next_last)
+                    JS_j=IV_index_down(JS_j)
+                end do
+                if (JS_j.eq.JS_next_last) then
+                    nb_intersection=nb_intersection+1
+                end if
+            end if
+
+        end do
+
+        if (nb_intersection.ne.0) then
+
+            if (JS_next_last.eq.IV_index_down(JS_riv_bas)) then
+
+                !ZS_val2=ZV_C1( down(JS_riv_bas) )
+                call VecGetValues(ZV_C1_zeroth,                                &
+                                  IS_one,                                      &
+                                  IV_index_down(JS_riv_bas)-1,                 &
+                                  ZS_val2,ierr)
+
+                !ZS_val = ZS_val*ZV_C1( down(JS_riv_bas) )
+                ZS_val = ZS_val*ZS_val2
+
+                !ZS_val2=ZV_C2( down(JS_riv_bas) )
+                call VecGetValues(ZV_C2_zeroth,                                &
+                                  IS_one,                                      &
+                                  IV_index_down(JS_riv_bas)-1,                 &
+                                  ZS_val2,ierr)
+
+               !ZS_val = ZS_val + ZV_C2( down(JS_riv_bas) )
+               !ZS_val = ZV_C3(JS_riv_bas)*ZV_C1( down(JS_riv_bas) ) + ZV_C2( down(JS_riv_bas) )
+               ZS_val = ZS_val + ZS_val2              
+
+            else
+
+                call VecGetValues(ZV_C1_zeroth,                                &
+                                  IS_one,                                      &
+                                  JS_next_last-1,                              &
+                                  ZS_val2,ierr)
+
+                ZS_val = ZS_val*ZS_val2
+
+            end if
+
+            call MatSetValues(ZM_L,                                        &
+                              IS_one,JS_next_last-1,                       &
+                              IS_one,JS_riv_bas-1,                         &
+                              ZS_val,INSERT_VALUES,                        &
+                              ierr)   
+
+            call MatSetValues(ZM_temp,                                     &
+                              IS_one,JS_next_last-1,                       &
+                              IS_one,JS_riv_bas-1,                         &
+                              ZS_val,INSERT_VALUES,                        &
+                              ierr)
+ 
+            IV_lastrow(JS_riv_bas) = JS_next_last
+            JS_next_last=IV_index_down(IV_lastrow(JS_riv_bas))
+            
+        else
+            found_nz=0
+
+        end if
+
+    end do
+
+    deallocate(IV_ind_rows) 
+
+end do
+
+end if
+
+!-------------------------------------------------------------------------------
+!Matrices assembly: ZM_temp
+!-------------------------------------------------------------------------------
+
+call MatAssemblyBegin(ZM_temp,MAT_FINAL_ASSEMBLY,ierr)
+call MatAssemblyEnd(ZM_temp,MAT_FINAL_ASSEMBLY,ierr)
+
+!-------------------------------------------------------------------------------
+!Poupulate the rest of ZM_L with 0s
+!-------------------------------------------------------------------------------
+
+if (rank.eq.0) then
+
+do while ( COUNT(IV_lastrow(1:IS_riv_bas).eq.0).ne.IS_riv_bas )
+
+    do JS_riv_bas=1,IS_riv_bas   !loop over column
+
+        JS_riv_bas2 = IV_index_down(IV_lastrow(JS_riv_bas))
+
+        call MatSetValues(ZM_L,                                                &
+                          IS_one,                                              &
+                          JS_riv_bas2-1,                                       &
+                          IS_one,                                              &
+                          JS_riv_bas-1,                                        &
+                          0*ZS_one,INSERT_VALUES,                              &
+                          ierr)
+
+        IV_lastrow(JS_riv_bas) = JS_riv_bas2
+
+    end do
+
+end do
+
+end if
+
+!-------------------------------------------------------------------------------
+!Matrices assembly: ZM_L
+!-------------------------------------------------------------------------------
+
+call MatAssemblyBegin(ZM_L,MAT_FINAL_ASSEMBLY,ierr)
+call MatAssemblyEnd(ZM_L,MAT_FINAL_ASSEMBLY,ierr)
+
+call PetscSynchronizedPrintf(PETSC_COMM_WORLD,'ZM_L assembled with 0s'//char(10),ierr)
+
+!*******************************************************************************
+!Build ZM_L
+!*******************************************************************************
+
+!-------------------------------------------------------------------------------
+!Initialize ZM_temp_pow as ZM_L (values+non-zeros pattern)
+!-------------------------------------------------------------------------------
+
+call MatDuplicate(ZM_L,MAT_COPY_VALUES,ZM_temp_pow,ierr)
+!ZM_temp_pow initialize as ZM_L = (I-C1*N)^(-1)*(C3+C2*N)
+!Same non-zero pattern as ZM_L (necessary to use MatMatMult)
+
+!-------------------------------------------------------------------------------
+!Update ZM_L to ((IS_RpM*IS_R-1)/(IS_RpM*IS_R))*ZM_L
+!-------------------------------------------------------------------------------
+
+ZS_factor = (REAL(IS_RpM*IS_R-1)/REAL(IS_RpM*IS_R))
+call MatScale(ZM_L,ZS_factor,ierr)
+
+!-------------------------------------------------------------------------------
+!Loop over (IS_RpM*IS_R)-1 steps to add all terms in ZM_L
+!-------------------------------------------------------------------------------
+
+do JS_p=2,(IS_RpM*IS_R-1)
+
+    call MatMatMult(ZM_temp_pow,                                               &
+                    ZM_temp,                                                   &
+                    MAT_INITIAL_MATRIX,                                        &
+                    PETSC_DEFAULT_REAL,                                        &
+                    ZM_temp2,ierr)
+
+    call MatCopy(ZM_temp2,ZM_temp_pow,SAME_NONZERO_PATTERN,ierr)
+    call MatDestroy(ZM_temp2,ierr)
+
+    ZS_factor = (REAL(IS_RpM*IS_R-JS_p)/REAL(IS_RpM*IS_R))
+
+    call MatAXPY(ZM_L,                                                         &
+                 ZS_factor,                                                    &
+                 ZM_temp_pow,                                                  &
+                 SAME_NONZERO_PATTERN,                                         &
+                 ierr)
+                 
+
+end do
+
+!-------------------------------------------------------------------------------
+!Add last term of the sum in ZL_L (power=0 <=> add identity)
+!-------------------------------------------------------------------------------
+
+call MatShift(ZM_L,ZS_one,ierr)
+
+!-------------------------------------------------------------------------------
+!Free memory
+!-------------------------------------------------------------------------------
+
+call MatDestroy(ZM_temp,ierr)
+call MatDestroy(ZM_temp_pow,ierr)
+
+!-------------------------------------------------------------------------------
+!Compute ZM_L = ZM_L*(I-C1*N)^(-1)*(C1+C2)
+!-------------------------------------------------------------------------------
+
+call MatMatMult(ZM_L,ZM_M,MAT_INITIAL_MATRIX,PETSC_DEFAULT_REAL,ZM_temp,ierr)
+!ZM_temp = ZL_L*ZL_M
+
+call VecCopy(ZV_C1,ZV_temp1,ierr)
+call VecAXPY(ZV_temp1,ZS_one,ZV_C2,ierr)
+!ZV_temp1 = ZV_C1+ZV_C2
+
+call MatDiagonalScale(ZM_temp,PETSC_NULL_OBJECT,ZV_temp1,ierr)
+!ZM_temp = !ZM_temp*diag(C1+C2)
+
+call MatCopy(ZM_temp,ZM_L,DIFFERENT_NONZERO_PATTERN,ierr)
+!ZM_L = ZM_temp
+
+
+call PetscPrintf(PETSC_COMM_WORLD,'Inverse runoff-discharge operator created'    &
+                                   //char(10),ierr)
+
+
+!*******************************************************************************
+!Free up memory used by local (temporary) variables
+!*******************************************************************************
+
+deallocate(IV_index_down)
+deallocate(IV_lastrow_save)
+
+call MatDestroy(ZM_temp,ierr)
+call VecScatterDestroy(vecscat_C1_zeroth,ierr)
+call VecScatterDestroy(vecscat_C2_zeroth,ierr)
+call VecScatterDestroy(vecscat_C2_zeroth,ierr)
+call VecDestroy(ZV_C1_zeroth,ierr)
+call VecDestroy(ZV_C2_zeroth,ierr)
+call VecDestroy(ZV_C3_zeroth,ierr)
+
+
+!*******************************************************************************
+!End subroutine 
+!*******************************************************************************
+end subroutine rapid_runoff2streamflow_mat


### PR DESCRIPTION
These commits updated the rapid_cov_mat subroutine so that the matrix is now of type "aij".